### PR TITLE
Add AWS support to quarkus build

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,6 @@ $ ./bin/trellis-db db migrate ./path/to/config.yml
 
 The docker image will handle this migration step automatically.
 
-
-
 ## Cloud-based storage
 
 A cloud-based container can be built with the

--- a/README.md
+++ b/README.md
@@ -9,7 +9,45 @@ For example, one extension uses a relational database to persist resources.
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/trellis-ldp/trellis-extensions.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/trellis-ldp/trellis-extensions/alerts/)
 ![Maven Central](https://img.shields.io/maven-central/v/org.trellisldp.ext/trellis-db.svg)
 
-## Database extension
+## Database persistence layer
+
+The databse persistence layer is considerably faster
+than using a triplestore. In some cases, it is an
+order of magnitude faster.
+
+PostgreSQL and embedded H2 database connections are supported.
+
+A [Docker container](https://hub.docker.com/r/trellisldp/trellis-database/) is available via:
+
+```sh
+docker pull trellisldp/trellis-database
+```
+
+By default, this container will use a local H2 database, but that is not recommended for production deployments.
+
+To configure the database for this container, the following environment variables
+should be set:
+
+```sh
+QUARKUS_DATASOURCE_DRIVER=org.postgresql.Driver
+QUARKUS_DATASOURCE_URL=jdbc:postgresql://db-host/db-name
+QUARKUS_DATASOURCE_USERNAME=user
+QUARKUS_DATASOURCE_PASSWORD=pass
+```
+
+By default, a database migration will run when the
+container is started. Once the database is set up,
+this step is no longer necessary and it can be
+disabled with the following environment variable:
+
+```sh
+QUARKUS_FLYWAY_MIGRATE_AT_START=false
+```
+
+## Legacy Database container
+
+A legacy database container is available using
+[Dropwizard](https://dropwizard.io).
 
 PostgreSQL and MySQL/MariaDB database connections are supported.
 
@@ -23,12 +61,6 @@ This container assumes the presence of an external database. Additional informat
 [running Trellis in a Docker container](https://github.com/trellis-ldp/trellis/wiki/Dockerized-Trellis)
 can be found on the TrellisLDP wiki.
 
-Java 8+ is required to run Trellis. To build this project, use this command:
-
-```sh
-$ ./gradlew install
-```
-
 ### Database setup
 
 In order to connect Trellis to a database, please first ensure that a database server is running and accessible. Please also
@@ -40,6 +72,34 @@ $ ./bin/trellis-db db migrate ./path/to/config.yml
 ```
 
 The docker image will handle this migration step automatically.
+
+
+
+## Cloud-based storage
+
+A cloud-based container can be built with the
+`-Pcloud` flag when running gradle.
+
+When using the AWS/Cloud extension with a docker
+container, the following environment variables need
+to be set (in addition to the database-related
+configuration):
+
+```sh
+AWS_ACCESS_KEY_ID=ABCDEFG
+AWS_SECRET_ACCESS_KEY=HIJKLMNOPQRSTUVWXYZ
+AWS_REGION=us-east-1
+
+TRELLIS_S3_MEMENTO_BUCKET=mementos.example.com
+TRELLIS_S3_BINARY_BUCKET=binaries.example.com
+TRELLIS_SNS_TOPIC=arn:aws:sns:us-east-1:123456789:MyTopic
+```
+
+Java 8+ is required to run Trellis. To build this project, use this command:
+
+```sh
+$ ./gradlew install
+```
 
 For more information about Trellis, please visit either the
 [main source repository](https://github.com/trellis-ldp/trellis) or the

--- a/aws/src/main/java/org/trellisldp/ext/aws/S3BinaryService.java
+++ b/aws/src/main/java/org/trellisldp/ext/aws/S3BinaryService.java
@@ -19,6 +19,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.runAsync;
 import static java.util.concurrent.CompletableFuture.supplyAsync;
 import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
+import static org.slf4j.LoggerFactory.getLogger;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -38,6 +39,7 @@ import javax.inject.Inject;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.rdf.api.IRI;
 import org.eclipse.microprofile.config.Config;
+import org.slf4j.Logger;
 import org.trellisldp.api.Binary;
 import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.BinaryService;
@@ -50,6 +52,8 @@ import org.trellisldp.api.RuntimeTrellisException;
  */
 @ApplicationScoped
 public class S3BinaryService implements BinaryService {
+
+    private static final Logger LOGGER = getLogger(S3BinaryService.class);
 
     public static final String CONFIG_BINARY_BUCKET = "trellis.s3.binary.bucket";
     public static final String CONFIG_BINARY_PATH_PREFIX = "trellis.s3.binary.path.prefix";
@@ -84,6 +88,7 @@ public class S3BinaryService implements BinaryService {
         this.client = requireNonNull(client, "client may not be null!");
         this.bucketName = requireNonNull(bucketName, "bucket name may not be null!");
         this.pathPrefix = pathPrefix != null ? pathPrefix : "";
+        LOGGER.info("Using AWS for binary persistence. S3 bucket: {}", bucketName);
     }
 
     @Override

--- a/aws/src/main/java/org/trellisldp/ext/aws/S3MementoService.java
+++ b/aws/src/main/java/org/trellisldp/ext/aws/S3MementoService.java
@@ -101,6 +101,7 @@ public class S3MementoService implements MementoService {
         this.client = requireNonNull(client, "S3 client may not be null!");
         this.bucketName = requireNonNull(bucketName, "AWS Bucket may not be null!");
         this.pathPrefix = pathPrefix != null ? pathPrefix : "";
+        LOGGER.info("Using AWS for memento persistence. S3 bucket: '{}'", bucketName);
     }
 
     @Override

--- a/aws/src/main/java/org/trellisldp/ext/aws/SNSEventService.java
+++ b/aws/src/main/java/org/trellisldp/ext/aws/SNSEventService.java
@@ -61,6 +61,7 @@ public class SNSEventService implements EventService {
         this.serializer = requireNonNull(serializer, "the event serializer may not be null!");
         this.sns = requireNonNull(client, "the SNS client may not be null!");
         this.topic = requireNonNull(topic, "the SNS topic may not be null!");
+        LOGGER.info("Using AWS for notifications. SNS topic: {}", topic);
     }
 
     @Override

--- a/platform/quarkus/build.gradle
+++ b/platform/quarkus/build.gradle
@@ -3,7 +3,8 @@ plugins {
 }
 
 def installForQuarkus = [
-    "trellis-db"
+    "trellis-db",
+    "trellis-aws"
 ]
 
 dependencies {
@@ -20,7 +21,6 @@ dependencies {
     implementation 'io.quarkus:quarkus-smallrye-health'
     implementation 'io.quarkus:quarkus-smallrye-metrics'
     implementation 'io.quarkus:quarkus-smallrye-openapi'
-    implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
 
     // Trellis Application
     implementation "org.trellisldp:trellis-app"
@@ -35,12 +35,19 @@ dependencies {
     implementation "org.trellisldp:trellis-cache"
     implementation "org.trellisldp:trellis-constraint-rules"
     implementation "org.trellisldp:trellis-event-jsonb"
-    implementation "org.trellisldp:trellis-file"
     implementation "org.trellisldp:trellis-io-jena"
     implementation "org.trellisldp:trellis-rdfa"
-    implementation "org.trellisldp:trellis-reactive"
     implementation "org.trellisldp:trellis-vocabulary"
+
+    // Persistence
     implementation "org.trellisldp.ext:trellis-db:${project.version}"
+    if (project.hasProperty("cloud")) {
+        implementation "org.trellisldp.ext:trellis-aws:${project.version}"
+    } else {
+        implementation "org.trellisldp:trellis-file"
+        implementation "org.trellisldp:trellis-reactive"
+        implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
+    }
 
     // Other dependencies
     implementation "com.github.spullara.mustache.java:compiler:$mustacheVersion"
@@ -73,6 +80,10 @@ test {
     systemProperty 'quarkus.flyway.migrate-at-start', 'true'
     systemProperty 'trellis.file.memento.basepath', "$buildDir/data/mementos"
     systemProperty 'trellis.file.binary.basepath', "$buildDir/data/binaries"
+    systemProperty "trellis.s3.memento.bucket", System.getenv("AWS_TEST_BUCKET") ?: "test.trellisldp.org"
+    systemProperty "trellis.s3.binary.bucket", System.getenv("AWS_TEST_BUCKET") ?: "test.trellisldp.org"
+    systemProperty "trellis.sns.topic", System.getenv("AWS_TEST_TOPIC") ?: "test-topic"
+
 }
 
 sonarqube {

--- a/platform/quarkus/src/main/resources/application.properties
+++ b/platform/quarkus/src/main/resources/application.properties
@@ -2,6 +2,12 @@
 trellis.db.batchSize=1000
 trellis.db.ldp.type=true
 
+# Trellis AWS
+trellis.s3.memento.bucket=
+trellis.s3.binary.bucket=
+trellis.sns.topic=
+
+
 # Trellis Auth
 trellis.auth.realm="trellis"
 trellis.auth.oauth.jwk=


### PR DESCRIPTION
This is mostly documentation and a bit of logging.

Functionally, this adds a profile to the gradle build `-Pcloud` that will turn on AWS-based persistence for the quarkus environment