### PR TITLE
Update cassandra project to work with quarkus

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,7 +5,7 @@ build_script:
     - gradlew.bat assemble
 
 test_script:
-    - gradlew.bat check --info --stacktrace
+    - gradlew.bat check
 
 cache:
     - .gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,11 +49,18 @@ jobs:
       script: travis_retry ./gradlew check -x pmdMain -x spotbugsMain install jacocoRootReport --continue --scan
       after_success: ./gradlew coveralls sonarqube
 
-    - name: "Java 8 (Quarkus)"
+    - name: "Java 8 (Quarkus Database)"
       stage: test
       jdk: openjdk8
       env: QUARKUS_EXTERNAL_PGSQL=true
-      script: travis_retry ./gradlew check -x :trellis-db-app:check -x pmdMain -x spotbugsMain install --continue --scan
+      script: ./gradlew check -p platform/quarkus -x pmdMain -x spotbugsMain install --scan
+
+    - name: "Java 8 (Quarkus Cassandra)"
+      stage: test
+      jdk: openjdk8
+      env: TEST_CASSANDRA_ENABLE=true
+      install: ./gradlew assemble -Pcassandra
+      script: ./gradlew check -x :trellis-db-app:check -x pmdMain -x spotbugsMain install -Pcassandra --scan
 
     # JDK 11
     - name: "Java 11"
@@ -96,9 +103,18 @@ jobs:
       if: branch = master AND type = push
       install: ./gradlew assemble -Pcloud
       before_script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
-      # Note: for maintenance branches, remove the dockerPushLatest task
-      script:
-          - ./buildtools/src/main/resources/docker/publishToDockerHub.sh "trellisldp/trellis-database-aws"
+      script: ./buildtools/src/main/resources/docker/publishToDockerHub.sh "trellisldp/trellis-database-aws"
+
+    # deploy to Docker hub
+    - name: "Publish to Docker hub (trellis-cassandra)"
+      stage: deploy
+      jdk: openjdk8
+      env: JOB=docker
+      # Note: allow maintenance branches
+      if: branch = master AND type = push
+      install: ./gradlew assemble -Pcassandra
+      before_script: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      script: ./buildtools/src/main/resources/docker/publishToDockerHub.sh "trellisldp/trellis-cassandra"
 
     - name: "Publish JavaDocs"
       stage: deploy

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraContext.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraContext.java
@@ -62,10 +62,6 @@ public class CassandraContext {
     String contactAddress;
 
     @Inject
-    @ConfigProperty(name = "trellis.cassandra.max-chunk-size", defaultValue = DefaultChunkSize.value)
-    String defaultChunkSize;
-
-    @Inject
     @ConfigProperty(name = "trellis.cassandra.binary-read-consistency", defaultValue = ONE)
     String binaryReadConsistency;
 
@@ -80,15 +76,6 @@ public class CassandraContext {
     @Inject
     @ConfigProperty(name = "trellis.cassandra.rdf-write-consistency", defaultValue = ONE)
     String rdfWriteConsistency;
-
-    /**
-     * @return the default size of chunk for a {@link CassandraBinaryService}
-     */
-    @Produces
-    @DefaultChunkSize
-    public int getChunkSize() {
-        return parseInt(defaultChunkSize);
-    }
 
     /**
      * @return the read-consistency to use querying Cassandra binary data

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraMementoService.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraMementoService.java
@@ -28,6 +28,7 @@ import java.util.TreeSet;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.Dataset;
@@ -44,8 +45,8 @@ import org.trellisldp.ext.cassandra.query.rdf.Mementos;
 
 /**
  * A {@link MementoService} that stores Mementos in a Cassandra table.
- *
  */
+@ApplicationScoped
 public class CassandraMementoService implements MementoService, CassandraBuildingService {
 
     private static final Logger LOGGER = getLogger(CassandraMementoService.class);
@@ -57,6 +58,10 @@ public class CassandraMementoService implements MementoService, CassandraBuildin
     private final GetMemento getMemento;
 
     private final GetFirstMemento getFirstMemento;
+
+    CassandraMementoService() {
+        this(null, null, null, null);
+    }
 
     @Inject
     CassandraMementoService(final Mementos mementos, final Mementoize mementoize, final GetMemento getMemento,

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraResourceService.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraResourceService.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 
 import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.Dataset;
@@ -65,6 +66,7 @@ import org.trellisldp.vocabulary.LDP;
  *
  * @author ajs6f
  */
+@ApplicationScoped
 class CassandraResourceService implements ResourceService, CassandraBuildingService {
 
     private static final Set<IRI> SUPPORTED_INTERACTION_MODELS;
@@ -90,6 +92,10 @@ class CassandraResourceService implements ResourceService, CassandraBuildingServ
     private final BasicContainment bcontainment;
 
     private final ImmutableRetrieve immutableRetrieve;
+
+    CassandraResourceService() {
+        this(null, null, null, null, null, null, null);
+    }
 
     @Inject
     CassandraResourceService(final Delete delete, final Get get, final ImmutableInsert immutableInsert,

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/binary/BinaryQuery.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/binary/BinaryQuery.java
@@ -18,9 +18,13 @@ import com.datastax.oss.driver.api.core.CqlSession;
 
 import org.trellisldp.ext.cassandra.query.CassandraQuery;
 
-abstract class BinaryQuery extends CassandraQuery {
+public abstract class BinaryQuery extends CassandraQuery {
 
     static final String BINARY_TABLENAME = "binarydata";
+
+    BinaryQuery() {
+        super();
+    }
 
     BinaryQuery(final CqlSession session, final String queryString, final ConsistencyLevel consistency) {
         super(session, queryString, consistency);

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/binary/BinaryReadQuery.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/binary/BinaryReadQuery.java
@@ -32,12 +32,17 @@ import org.trellisldp.ext.cassandra.LazyChunkInputStream;
 /**
  * A query that reads binary data from Cassandra.
  */
-abstract class BinaryReadQuery extends BinaryQuery {
+public abstract class BinaryReadQuery extends BinaryQuery {
 
     private static final String READ_CHUNK_QUERY = "SELECT chunk FROM " + BINARY_TABLENAME
                     + " WHERE identifier = :identifier and chunkIndex = :chunkIndex;";
 
     private final PreparedStatement readChunkStatement;
+
+    BinaryReadQuery() {
+        super();
+        this.readChunkStatement = null;
+    }
 
     BinaryReadQuery(final CqlSession session, final String queryString, final ConsistencyLevel consistency) {
         super(session, queryString, consistency);

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/binary/Read.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/binary/Read.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.cql.BoundStatement;
 
 import java.io.InputStream;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.IRI;
@@ -28,7 +29,18 @@ import org.trellisldp.ext.cassandra.BinaryReadConsistency;
  * Reads all bytes from a binary to an {@link InputStream}.
  *
  */
+@ApplicationScoped
 public class Read extends BinaryReadQuery {
+
+    /**
+     * For use with RESTeasy and CDI proxies.
+     *
+     * @apiNote This construtor is used by CDI runtimes that require a public, no-argument constructor.
+     *          It should not be invoked directly in user code.
+     */
+    public Read() {
+        super();
+    }
 
     /**
      * @param session the cassandra session

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/binary/ReadRange.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/binary/ReadRange.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.cql.BoundStatement;
 
 import java.io.InputStream;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.IRI;
@@ -27,7 +28,18 @@ import org.trellisldp.ext.cassandra.BinaryReadConsistency;
 /**
  * Reads a range of bytes from a binary to an {@link InputStream}.
  */
+@ApplicationScoped
 public class ReadRange extends BinaryReadQuery {
+
+    /**
+     * For use with RESTeasy and CDI proxies.
+     *
+     * @apiNote This construtor is used by CDI runtimes that require a public, no-argument constructor.
+     *          It should not be invoked directly in user code.
+     */
+    public ReadRange() {
+        super();
+    }
 
     /**
      * @param session the cassandra session

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/Delete.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/Delete.java
@@ -13,21 +13,37 @@
  */
 package org.trellisldp.ext.cassandra.query.rdf;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.cql.BoundStatement;
 
 import java.util.concurrent.CompletionStage;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.IRI;
+import org.slf4j.Logger;
 import org.trellisldp.ext.cassandra.MutableWriteConsistency;
 
 /**
  * A query to delete a resource.
  */
+@ApplicationScoped
 public class Delete extends ResourceQuery {
+
+    private static final Logger LOGGER = getLogger(Delete.class);
+
+    /**
+     * For use with RESTeasy and CDI proxies.
+     *
+     * @apiNote This construtor is used by CDI runtimes that require a public, no-argument constructor.
+     *          It should not be invoked directly in user code.
+     */
+    public Delete() {
+        super();
+    }
 
     /**
      * A query that deletes a resource.
@@ -44,7 +60,9 @@ public class Delete extends ResourceQuery {
      * @return whether and when it has been deleted
      */
     public CompletionStage<Void> execute(final IRI id) {
-        final BoundStatement statement = preparedStatement().bind().set("identifier", id, IRI.class);
-        return executeWrite(statement);
+        return preparedStatementAsync().thenApply(stmt ->
+                stmt.bind().set("identifier", id, IRI.class).setConsistencyLevel(consistency))
+            .thenCompose(session::executeAsync)
+            .thenAccept(r -> LOGGER.debug("Executed query: {}", queryString));
     }
 }

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/Get.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/Get.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 
 import java.util.concurrent.CompletionStage;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.IRI;
@@ -27,7 +28,18 @@ import org.trellisldp.ext.cassandra.MutableReadConsistency;
 /**
  * Retrieve data for a resource.
  */
+@ApplicationScoped
 public class Get extends ResourceQuery {
+
+    /**
+     * For use with RESTeasy and CDI proxies.
+     *
+     * @apiNote This construtor is used by CDI runtimes that require a public, no-argument constructor.
+     *          It should not be invoked directly in user code.
+     */
+    public Get() {
+        super();
+    }
 
     /**
      * Retrieve data for a resource.
@@ -44,6 +56,7 @@ public class Get extends ResourceQuery {
      * @return a {@link AsyncResultSet} of the resource data
      */
     public CompletionStage<AsyncResultSet> execute(final IRI id) {
-        return executeRead(preparedStatement().bind().set("identifier", id, IRI.class));
+        return preparedStatementAsync().thenApply(stmt -> stmt.bind().set("identifier", id, IRI.class))
+            .thenCompose(session::executeAsync);
     }
 }

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/GetFirstMemento.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/GetFirstMemento.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 
 import java.util.concurrent.CompletionStage;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.IRI;
@@ -27,7 +28,18 @@ import org.trellisldp.ext.cassandra.MutableReadConsistency;
 /**
  * Retrieve data for the first Memento of a resource.
  */
+@ApplicationScoped
 public class GetFirstMemento extends ResourceQuery {
+
+    /**
+     * For use with RESTeasy and CDI proxies.
+     *
+     * @apiNote This construtor is used by CDI runtimes that require a public, no-argument constructor.
+     *          It should not be invoked directly in user code.
+     */
+    public GetFirstMemento() {
+        super();
+    }
 
     /**
      * Create an object that retrieves data for the first Memento of a resource.
@@ -45,6 +57,7 @@ public class GetFirstMemento extends ResourceQuery {
      * @return the data for the Memento
      */
     public CompletionStage<AsyncResultSet> execute(final IRI id) {
-        return executeRead(preparedStatement().bind().set("identifier", id, IRI.class));
+        return preparedStatementAsync().thenApply(stmt -> stmt.bind().set("identifier", id, IRI.class))
+            .thenCompose(session::executeAsync);
     }
 }

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/GetMemento.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/GetMemento.java
@@ -16,11 +16,11 @@ package org.trellisldp.ext.cassandra.query.rdf;
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
-import com.datastax.oss.driver.api.core.cql.BoundStatement;
 
 import java.time.Instant;
 import java.util.concurrent.CompletionStage;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.IRI;
@@ -29,7 +29,18 @@ import org.trellisldp.ext.cassandra.MutableReadConsistency;
 /**
  * Retrieve data for a Memento.
  */
+@ApplicationScoped
 public class GetMemento extends ResourceQuery {
+
+    /**
+     * For use with RESTeasy and CDI proxies.
+     *
+     * @apiNote This construtor is used by CDI runtimes that require a public, no-argument constructor.
+     *          It should not be invoked directly in user code.
+     */
+    public GetMemento() {
+        super();
+    }
 
     /**
      * A class that retrieves data for a Memento.
@@ -49,9 +60,8 @@ public class GetMemento extends ResourceQuery {
      * @return the data for the Memento
      */
     public CompletionStage<AsyncResultSet> execute(final IRI id, final Instant time) {
-        final BoundStatement statement = preparedStatement().bind()
-                        .set("time", time, Instant.class)
-                        .set("identifier", id, IRI.class);
-        return executeRead(statement);
+        return preparedStatementAsync().thenApply(stmt -> stmt.bind().set("time", time, Instant.class)
+                .set("identifier", id, IRI.class))
+            .thenCompose(session::executeAsync);
     }
 }

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/Mementos.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/Mementos.java
@@ -19,6 +19,7 @@ import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 
 import java.util.concurrent.CompletionStage;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.IRI;
@@ -27,7 +28,18 @@ import org.trellisldp.ext.cassandra.MutableReadConsistency;
 /**
  * A query to retrieve a list of the Mementos of a resource.
  */
+@ApplicationScoped
 public class Mementos extends ResourceQuery {
+
+    /**
+     * For use with RESTeasy and CDI proxies.
+     *
+     * @apiNote This construtor is used by CDI runtimes that require a public, no-argument constructor.
+     *          It should not be invoked directly in user code.
+     */
+    public Mementos() {
+        super();
+    }
 
     /**
      * Create a query that retrieves a list of mementos.
@@ -46,6 +58,7 @@ public class Mementos extends ResourceQuery {
      *         There will be at least one (the most recent one).
      */
     public CompletionStage<AsyncResultSet> execute(final IRI id) {
-        return executeRead(preparedStatement().bind().set("identifier", id, IRI.class));
+        return preparedStatementAsync().thenApply(stmt -> stmt.bind().set("identifier", id, IRI.class))
+            .thenCompose(session::executeAsync);
     }
 }

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/MutableInsert.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/MutableInsert.java
@@ -13,24 +13,40 @@
  */
 package org.trellisldp.ext.cassandra.query.rdf;
 
+import static org.slf4j.LoggerFactory.getLogger;
+
 import com.datastax.oss.driver.api.core.ConsistencyLevel;
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.cql.BoundStatement;
 
 import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 
+import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
+import org.slf4j.Logger;
 import org.trellisldp.ext.cassandra.MutableWriteConsistency;
 
 /**
  * A query to insert mutable data about a resource into Cassandra.
  */
+@ApplicationScoped
 public class MutableInsert extends ResourceQuery {
+
+    private static final Logger LOGGER = getLogger(MutableInsert.class);
+
+    /**
+     * For use with RESTeasy and CDI proxies.
+     *
+     * @apiNote This construtor is used by CDI runtimes that require a public, no-argument constructor.
+     *          It should not be invoked directly in user code.
+     */
+    public MutableInsert() {
+        super();
+    }
 
     /**
      * A query that inserts mutable data into Cassandra.
@@ -57,8 +73,10 @@ public class MutableInsert extends ResourceQuery {
      */
     public CompletionStage<Void> execute(final IRI ixnModel, final String mimeType, final IRI container,
             final Dataset data, final Instant modified, final IRI binaryIdentifier, final UUID creation, final IRI id) {
-        final BoundStatement statement = preparedStatement().bind(ixnModel, mimeType, container, data, modified,
-                        binaryIdentifier, creation, id);
-        return executeWrite(statement);
+        return preparedStatementAsync().thenApply(stmt ->
+                stmt.bind(ixnModel, mimeType, container, data, modified, binaryIdentifier, creation, id)
+                    .setConsistencyLevel(consistency))
+            .thenCompose(session::executeAsync)
+            .thenAccept(r -> LOGGER.debug("Executed query: {}", queryString));
     }
 }

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/ResourceQuery.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/ResourceQuery.java
@@ -31,6 +31,10 @@ abstract class ResourceQuery extends CassandraQuery {
 
     static final String BASIC_CONTAINMENT_TABLENAME = "basiccontainment";
 
+    ResourceQuery() {
+        super();
+    }
+
     ResourceQuery(final CqlSession session, final String queryString, final ConsistencyLevel consistency) {
         super(session, queryString, consistency);
     }

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/Touch.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/Touch.java
@@ -34,7 +34,7 @@ import org.trellisldp.ext.cassandra.MutableWriteConsistency;
 @ApplicationScoped
 public class Touch extends ResourceQuery {
 
-    private static Logger LOGGER = getLogger(Touch.class);
+    private static final Logger LOGGER = getLogger(Touch.class);
 
     /**
      * For use with RESTeasy and CDI proxies.

--- a/cassandra/src/test/java/org/trellisldp/ext/cassandra/CassandraBinaryServiceIT.java
+++ b/cassandra/src/test/java/org/trellisldp/ext/cassandra/CassandraBinaryServiceIT.java
@@ -140,6 +140,11 @@ class CassandraBinaryServiceIT extends CassandraServiceIT {
         }
     }
 
+    @Test
+    void testNoArgCtor() {
+        assertDoesNotThrow(() -> new CassandraBinaryService());
+    }
+
     private IRI createIRI() {
         return rdfFactory.createIRI("http://example.com/" + randomUUID());
     }

--- a/cassandra/src/test/java/org/trellisldp/ext/cassandra/CassandraConnection.java
+++ b/cassandra/src/test/java/org/trellisldp/ext/cassandra/CassandraConnection.java
@@ -94,7 +94,7 @@ class CassandraConnection implements AfterAllCallback, BeforeAllCallback {
         this.mementoService = new CassandraMementoService(new Mementos(session, testConsistency),
                         new Mementoize(session, testConsistency), new GetMemento(session, testConsistency),
                         new GetFirstMemento(session, testConsistency));
-        this.binaryService = new CassandraBinaryService((IdentifierService) null, 1024 * 1024,
+        this.binaryService = new CassandraBinaryService((IdentifierService) null,
                         new GetChunkSize(session, testConsistency),
                         new Insert(session, testConsistency),
                         new org.trellisldp.ext.cassandra.query.binary.Delete(session, testConsistency),

--- a/cassandra/src/test/java/org/trellisldp/ext/cassandra/CassandraContextIT.java
+++ b/cassandra/src/test/java/org/trellisldp/ext/cassandra/CassandraContextIT.java
@@ -73,9 +73,4 @@ class CassandraContextIT {
     void testRdfWriteConsistency() {
         assertEquals(DefaultConsistencyLevel.ONE, ctx.getRdfWriteConsistency());
     }
-
-    @Test
-    void testDefaultChunkSize() {
-        assertEquals(Integer.parseInt(DefaultChunkSize.value), ctx.getChunkSize());
-    }
 }

--- a/cassandra/src/test/java/org/trellisldp/ext/cassandra/CassandraMementoServiceIT.java
+++ b/cassandra/src/test/java/org/trellisldp/ext/cassandra/CassandraMementoServiceIT.java
@@ -14,7 +14,7 @@
 package org.trellisldp.ext.cassandra;
 
 import static java.util.UUID.randomUUID;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.trellisldp.api.Metadata.builder;
 
 import java.time.Instant;
@@ -49,6 +49,9 @@ class CassandraMementoServiceIT extends CassandraServiceIT {
 
         SortedSet<Instant> mementos = connection.mementoService.mementos(id).toCompletableFuture().join();
         assertEquals(1, mementos.size());
+
+        assertEquals(id, connection.mementoService.get(id, mementos.first()).toCompletableFuture().join()
+                .getIdentifier());
         waitTwoSeconds();
 
         // again
@@ -57,5 +60,15 @@ class CassandraMementoServiceIT extends CassandraServiceIT {
 
         mementos = connection.mementoService.mementos(id).toCompletableFuture().join();
         assertEquals(2, mementos.size());
+
+        mementos.forEach(time ->
+            assertEquals(id, connection.mementoService.get(id, time).toCompletableFuture().join()
+                .getIdentifier()));
+
+    }
+
+    @Test
+    void testNoArgCtor() {
+        assertDoesNotThrow(() -> new CassandraMementoService());
     }
 }

--- a/cassandra/src/test/java/org/trellisldp/ext/cassandra/CassandraResourceServiceIT.java
+++ b/cassandra/src/test/java/org/trellisldp/ext/cassandra/CassandraResourceServiceIT.java
@@ -13,8 +13,7 @@
  */
 package org.trellisldp.ext.cassandra;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.trellisldp.api.Metadata.builder;
 
 import java.time.Instant;
@@ -67,6 +66,11 @@ class CassandraResourceServiceIT extends CassandraServiceIT implements ResourceS
         final Instant newModified = connection.resourceService.get(container)
             .toCompletableFuture().join().getModified();
         assertTrue(modified.compareTo(newModified) < 0);
+    }
+
+    @Test
+    void testNoArgCtor() {
+        assertDoesNotThrow(() -> new CassandraResourceService());
     }
 
     @Override

--- a/cassandra/src/test/java/org/trellisldp/ext/cassandra/query/binary/CassandraBinaryQueryTest.java
+++ b/cassandra/src/test/java/org/trellisldp/ext/cassandra/query/binary/CassandraBinaryQueryTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.cassandra.query.binary;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class CassandraBinaryQueryTest {
+
+    @Test
+    void testNoArgBinaryReadQuery() {
+        assertDoesNotThrow(() -> new Read());
+    }
+
+    @Test
+    void testNoArgBinaryReadRangeQuery() {
+        assertDoesNotThrow(() -> new ReadRange());
+    }
+
+    @Test
+    void testNoArgGetChunkSizeQuery() {
+        assertDoesNotThrow(() -> new GetChunkSize());
+    }
+
+    @Test
+    void testNoArgBinaryDeleteQuery() {
+        assertDoesNotThrow(() -> new Delete());
+    }
+
+    @Test
+    void testNoArgBinaryInsertQuery() {
+        assertDoesNotThrow(() -> new Insert());
+    }
+}

--- a/cassandra/src/test/java/org/trellisldp/ext/cassandra/query/rdf/CassandraRdfQueryTest.java
+++ b/cassandra/src/test/java/org/trellisldp/ext/cassandra/query/rdf/CassandraRdfQueryTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.cassandra.query.rdf;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class CassandraRdfQueryTest {
+
+    @Test
+    void testNoArgRdfGetQuery() {
+        assertDoesNotThrow(() -> new Get());
+    }
+
+    @Test
+    void testNoArgRdfBasicContainmentQuery() {
+        assertDoesNotThrow(() -> new BasicContainment());
+    }
+
+    @Test
+    void testNoArgRdfImmutableRetrieveQuery() {
+        assertDoesNotThrow(() -> new ImmutableRetrieve());
+    }
+
+    @Test
+    void testNoArgRdfDeleteQuery() {
+        assertDoesNotThrow(() -> new Delete());
+    }
+
+    @Test
+    void testNoArgRdfMutableInsertQuery() {
+        assertDoesNotThrow(() -> new MutableInsert());
+    }
+
+    @Test
+    void testNoArgRdfMementosQuery() {
+        assertDoesNotThrow(() -> new Mementos());
+    }
+
+    @Test
+    void testNoArgRdfGetFirstMementoQuery() {
+        assertDoesNotThrow(() -> new GetFirstMemento());
+    }
+
+    @Test
+    void testNoArgRdfTouchQuery() {
+        assertDoesNotThrow(() -> new Touch());
+    }
+
+    @Test
+    void testNoArgRdfGetMementoQuery() {
+        assertDoesNotThrow(() -> new GetMemento());
+    }
+
+    @Test
+    void testNoArgRdfImmutableInsertQuery() {
+        assertDoesNotThrow(() -> new ImmutableInsert());
+    }
+
+    @Test
+    void testNoArgRdfMementoizeQuery() {
+        assertDoesNotThrow(() -> new Mementoize());
+    }
+}

--- a/namespaces/build.gradle
+++ b/namespaces/build.gradle
@@ -1,0 +1,27 @@
+apply plugin: 'java-library'
+
+description = 'Trellis Namespaces'
+
+ext {
+    moduleName = 'org.trellisldp.ext.namespaces'
+}
+
+dependencies {
+    implementation enforcedPlatform("org.trellisldp:trellis-bom:$trellisVersion")
+
+    api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
+    api "org.trellisldp:trellis-api"
+
+    implementation "org.eclipse.microprofile.config:microprofile-config-api:$microprofileConfigVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation "org.trellisldp:trellis-vocabulary"
+
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
+    testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
+    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+}
+
+test {
+    systemProperty 'trellis.namespace.prefixes', 'dc11=http://purl.org/dc/elements/1.1/,,foo= , =bar,baz, = '
+}

--- a/namespaces/src/main/java/org/trellisldp/ext/namespaces/SimpleNamespaceService.java
+++ b/namespaces/src/main/java/org/trellisldp/ext/namespaces/SimpleNamespaceService.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.namespaces;
+
+import static java.util.Arrays.stream;
+import static java.util.Collections.unmodifiableMap;
+import static java.util.stream.Collectors.toMap;
+import static org.eclipse.microprofile.config.ConfigProvider.getConfig;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.trellisldp.api.NamespaceService;
+import org.trellisldp.vocabulary.ACL;
+import org.trellisldp.vocabulary.AS;
+import org.trellisldp.vocabulary.DC;
+import org.trellisldp.vocabulary.FOAF;
+import org.trellisldp.vocabulary.LDP;
+import org.trellisldp.vocabulary.RDF;
+import org.trellisldp.vocabulary.RDFS;
+import org.trellisldp.vocabulary.SKOS;
+import org.trellisldp.vocabulary.VCARD;
+import org.trellisldp.vocabulary.XSD;
+
+/**
+ * A simple, in-memory namespace service.
+ *
+ * <p>This service will load some standard namespaces/prefixes and read
+ * system properties into the namespace maping if they are defined like so:
+ * "trellis.ns-myprefix=http://example.com/namespace"
+ */
+@ApplicationScoped
+public class SimpleNamespaceService implements NamespaceService {
+
+    public static final String CONFIG_NAMESPACE_PREFIXES = "trellis.namespace.prefixes";
+
+    private final Map<String, String> namespaces = new HashMap<>();
+
+    /**
+     * Create a simple, in-memory namespace service.
+     */
+    public SimpleNamespaceService() {
+        namespaces.put("ldp", LDP.getNamespace());
+        namespaces.put("acl", ACL.getNamespace());
+        namespaces.put("as", AS.getNamespace());
+        namespaces.put("dc", DC.getNamespace());
+        namespaces.put("rdf", RDF.getNamespace());
+        namespaces.put("rdfs", RDFS.getNamespace());
+        namespaces.put("skos", SKOS.getNamespace());
+        namespaces.put("xsd", XSD.getNamespace());
+        namespaces.put("foaf", FOAF.getNamespace());
+        namespaces.put("vcard", VCARD.getNamespace());
+        getConfig().getOptionalValue(CONFIG_NAMESPACE_PREFIXES, String.class).map(SimpleNamespaceService::configToMap)
+            .ifPresent(data -> data.forEach(namespaces::put));
+    }
+
+    @Override
+    public Map<String, String> getNamespaces() {
+        return unmodifiableMap(namespaces);
+    }
+
+    @Override
+    public boolean setPrefix(final String prefix, final String namespace) {
+        return true;
+    }
+
+    static Map<String, String> configToMap(final String config) {
+        return stream(config.split(",")).map(item -> item.split("=")).filter(kv -> kv.length == 2)
+            .filter(kv -> !kv[0].trim().isEmpty() && !kv[1].trim().isEmpty())
+            .collect(toMap(kv -> kv[0].trim(), kv -> kv[1].trim()));
+    }
+}

--- a/namespaces/src/main/java/org/trellisldp/ext/namespaces/package-info.java
+++ b/namespaces/src/main/java/org/trellisldp/ext/namespaces/package-info.java
@@ -13,6 +13,6 @@
  */
 
 /**
- * A microprofile-based Trellis application.
+ * Trellis namespaces implementation.
  */
-package org.trellisldp.ext.db.webapp;
+package org.trellisldp.ext.namespaces;

--- a/namespaces/src/main/resources/META-INF/beans.xml
+++ b/namespaces/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd" version="1.1"
+  bean-discovery-mode="all">
+
+</beans>

--- a/namespaces/src/test/java/org/trellisldp/ext/namespaces/SimpleNamespaceServiceTest.java
+++ b/namespaces/src/test/java/org/trellisldp/ext/namespaces/SimpleNamespaceServiceTest.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.namespaces;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.trellisldp.api.NamespaceService;
+
+public class SimpleNamespaceServiceTest {
+
+    @Test
+    public void testNamespace() {
+        final NamespaceService svc = new SimpleNamespaceService();
+        assertEquals(11, svc.getNamespaces().size());
+        assertTrue(svc.setPrefix("foo", "bar"));
+        assertEquals(11, svc.getNamespaces().size());
+    }
+
+    @Test
+    public void testEnvNamespace() {
+        final NamespaceService svc = new SimpleNamespaceService();
+        final String dc11 = "http://purl.org/dc/elements/1.1/";
+        assertEquals(dc11, svc.getNamespaces().get("dc11"));
+    }
+}

--- a/platform/bom/build.gradle
+++ b/platform/bom/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     implementation project(':trellis-cassandra')
     implementation project(':trellis-db')
     implementation project(':trellis-db-app')
-    implementation project(':trellis-db-quarkus')
+    implementation project(':trellis-namespaces')
+    implementation project(':trellis-quarkus')
 }
 
 publishing {

--- a/platform/quarkus/build.gradle
+++ b/platform/quarkus/build.gradle
@@ -40,10 +40,10 @@ dependencies {
     // Persistence
     if (project.hasProperty("cassandra")) {
         // Cassandra dependencies
+        implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
         implementation "org.trellisldp.ext:trellis-cassandra:${project.version}"
         implementation "org.trellisldp.ext:trellis-namespaces:${project.version}"
         implementation "org.trellisldp:trellis-reactive"
-        implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
     } else {
         // Database dependencies
         implementation 'io.quarkus:quarkus-agroal'
@@ -55,9 +55,9 @@ dependencies {
         if (project.hasProperty("cloud")) {
             implementation "org.trellisldp.ext:trellis-aws:${project.version}"
         } else {
+            implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
             implementation "org.trellisldp:trellis-file"
             implementation "org.trellisldp:trellis-reactive"
-            implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
         }
     }
 

--- a/platform/quarkus/build.gradle
+++ b/platform/quarkus/build.gradle
@@ -3,18 +3,16 @@ plugins {
 }
 
 def installForQuarkus = [
+    "trellis-aws",
+    "trellis-cassandra",
     "trellis-db",
-    "trellis-aws"
+    "trellis-namespaces"
 ]
 
 dependencies {
     implementation enforcedPlatform("io.quarkus:quarkus-bom:$quarkusVersion")
     implementation enforcedPlatform("org.trellisldp:trellis-bom:$trellisVersion")
 
-    implementation 'io.quarkus:quarkus-agroal'
-    implementation 'io.quarkus:quarkus-flyway'
-    implementation 'io.quarkus:quarkus-jdbc-h2'
-    implementation 'io.quarkus:quarkus-jdbc-postgresql'
     implementation 'io.quarkus:quarkus-jsonb'
     implementation 'io.quarkus:quarkus-resteasy'
     implementation 'io.quarkus:quarkus-security'
@@ -40,13 +38,27 @@ dependencies {
     implementation "org.trellisldp:trellis-vocabulary"
 
     // Persistence
-    implementation "org.trellisldp.ext:trellis-db:${project.version}"
-    if (project.hasProperty("cloud")) {
-        implementation "org.trellisldp.ext:trellis-aws:${project.version}"
-    } else {
-        implementation "org.trellisldp:trellis-file"
+    if (project.hasProperty("cassandra")) {
+        // Cassandra dependencies
+        implementation "org.trellisldp.ext:trellis-cassandra:${project.version}"
+        implementation "org.trellisldp.ext:trellis-namespaces:${project.version}"
         implementation "org.trellisldp:trellis-reactive"
         implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
+    } else {
+        // Database dependencies
+        implementation 'io.quarkus:quarkus-agroal'
+        implementation 'io.quarkus:quarkus-flyway'
+        implementation 'io.quarkus:quarkus-jdbc-h2'
+        implementation 'io.quarkus:quarkus-jdbc-postgresql'
+        implementation "org.trellisldp.ext:trellis-db:${project.version}"
+
+        if (project.hasProperty("cloud")) {
+            implementation "org.trellisldp.ext:trellis-aws:${project.version}"
+        } else {
+            implementation "org.trellisldp:trellis-file"
+            implementation "org.trellisldp:trellis-reactive"
+            implementation 'io.quarkus:quarkus-smallrye-reactive-messaging'
+        }
     }
 
     // Other dependencies
@@ -83,6 +95,17 @@ test {
     systemProperty "trellis.s3.memento.bucket", System.getenv("AWS_TEST_BUCKET") ?: "test.trellisldp.org"
     systemProperty "trellis.s3.binary.bucket", System.getenv("AWS_TEST_BUCKET") ?: "test.trellisldp.org"
     systemProperty "trellis.sns.topic", System.getenv("AWS_TEST_TOPIC") ?: "test-topic"
+
+    if (project.hasProperty("cassandra")) {
+        systemProperty "trellis.test.cassandra.enable", project.findProperty("trellis.test.cassandra.enable") ?: System.getenv("TEST_CASSANDRA_ENABLE")
+    } else {
+        // enable the db tests
+        if (System.getenv("QUARKUS_EXTERNAL_PGSQL")) {
+            systemProperty 'trellis.test.quarkus.external-pgsql', 'true'
+        } else {
+            systemProperty 'trellis.test.quarkus.embedded-pgsql', 'true'
+        }
+    }
 
 }
 

--- a/platform/quarkus/build.gradle
+++ b/platform/quarkus/build.gradle
@@ -83,6 +83,8 @@ dependencies {
     testImplementation "io.quarkus:quarkus-junit5"
     testImplementation "io.rest-assured:rest-assured"
     testImplementation "org.apache.commons:commons-text:$commonsTextVersion"
+    testImplementation "org.jboss.resteasy:resteasy-client"
+    testImplementation "org.trellisldp:trellis-test"
 }
 
 test {
@@ -92,6 +94,7 @@ test {
     systemProperty 'quarkus.flyway.migrate-at-start', 'true'
     systemProperty 'trellis.file.memento.basepath', "$buildDir/data/mementos"
     systemProperty 'trellis.file.binary.basepath', "$buildDir/data/binaries"
+    systemProperty 'trellis.http.weak.etag', 'true'
     systemProperty "trellis.s3.memento.bucket", System.getenv("AWS_TEST_BUCKET") ?: "test.trellisldp.org"
     systemProperty "trellis.s3.binary.bucket", System.getenv("AWS_TEST_BUCKET") ?: "test.trellisldp.org"
     systemProperty "trellis.sns.topic", System.getenv("AWS_TEST_TOPIC") ?: "test-topic"

--- a/platform/quarkus/src/main/java/org/trellisldp/ext/webapp/AuthorizationCache.java
+++ b/platform/quarkus/src/main/java/org/trellisldp/ext/webapp/AuthorizationCache.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.trellisldp.ext.db.webapp;
+package org.trellisldp.ext.webapp;
 
 import static com.google.common.cache.CacheBuilder.newBuilder;
 import static java.util.concurrent.TimeUnit.SECONDS;

--- a/platform/quarkus/src/main/java/org/trellisldp/ext/webapp/ProfileCache.java
+++ b/platform/quarkus/src/main/java/org/trellisldp/ext/webapp/ProfileCache.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.trellisldp.ext.db.webapp;
+package org.trellisldp.ext.webapp;
 
 import static com.google.common.cache.CacheBuilder.newBuilder;
 import static java.util.concurrent.TimeUnit.HOURS;

--- a/platform/quarkus/src/main/java/org/trellisldp/ext/webapp/TrellisApplication.java
+++ b/platform/quarkus/src/main/java/org/trellisldp/ext/webapp/TrellisApplication.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.trellisldp.ext.db.webapp;
+package org.trellisldp.ext.webapp;
 
 import static org.trellisldp.app.AppUtils.printBanner;
 

--- a/platform/quarkus/src/main/java/org/trellisldp/ext/webapp/package-info.java
+++ b/platform/quarkus/src/main/java/org/trellisldp/ext/webapp/package-info.java
@@ -11,25 +11,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.trellisldp.ext.cassandra;
-
-import static java.lang.annotation.RetentionPolicy.RUNTIME;
-
-import java.lang.annotation.Documented;
-import java.lang.annotation.Retention;
-
-import javax.inject.Qualifier;
 
 /**
- * The default size of any chunk in this service.
+ * A microprofile-based Trellis application.
  */
-@Documented
-@Retention(RUNTIME)
-@Qualifier
-public @interface DefaultChunkSize {
-
-    /**
-     * Default chunk size to use.
-     */
-    String value = "1048576";
-}
+package org.trellisldp.ext.webapp;

--- a/platform/quarkus/src/main/resources/application.properties
+++ b/platform/quarkus/src/main/resources/application.properties
@@ -7,6 +7,16 @@ trellis.s3.memento.bucket=
 trellis.s3.binary.bucket=
 trellis.sns.topic=
 
+# Trellis Cassandra
+trellis.cassandra.keyspace=
+trellis.cassandra.datacenter=
+trellis.cassandra.contact-port=
+trellis.cassandra.contact-address=
+trellis.cassandra.max-chunk-size=
+trellis.cassandra.binary-read-consistency=
+trellis.cassandra.binary-write-consistency=
+trellis.cassandra.rdf-read-consisteny=
+trellis.cassandra.rdf-write-consistency=
 
 # Trellis Auth
 trellis.auth.realm="trellis"
@@ -69,7 +79,7 @@ quarkus.datasource.driver=org.h2.Driver
 quarkus.datasource.url=jdbc:h2:file:./data/resources.db
 quarkus.datasource.username=trellis
 quarkus.datasource.password=changeme
-quarkus.datasource.min-size=0
+quarkus.datasource.min-size=3
 quarkus.datasource.max-size=20
 
 # Flyway configuration

--- a/platform/quarkus/src/main/resources/application.properties
+++ b/platform/quarkus/src/main/resources/application.properties
@@ -81,7 +81,3 @@ quarkus.datasource.username=trellis
 quarkus.datasource.password=changeme
 quarkus.datasource.min-size=3
 quarkus.datasource.max-size=20
-
-# Flyway configuration
-quarkus.flyway.migrate-at-start=true
-quarkus.flyway.baseline-on-migrate=false

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractApplicationTests.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractApplicationTests.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.trellisldp.ext.db.webapp;
+package org.trellisldp.ext.webapp;
 
 import static io.restassured.RestAssured.get;
 import static io.restassured.RestAssured.given;
@@ -24,20 +24,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 
 abstract class AbstractApplicationTests {
-
-    @Test
-    void healthCheckTest() {
-        given().when().get("/health").then().assertThat()
-            .contentType(ContentType.JSON)
-            .statusCode(200);
-    }
-
-    @Test
-    void readinessCheckTest() {
-        given().when().get("/health/ready").then().assertThat()
-            .contentType(ContentType.JSON)
-            .statusCode(200);
-    }
 
     @Test
     void livenessCheckTest() {

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractLdpBasicContainmentTests.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractLdpBasicContainmentTests.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static javax.ws.rs.client.ClientBuilder.newBuilder;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+
+import java.net.URL;
+
+import javax.ws.rs.client.Client;
+
+import org.trellisldp.test.LdpBasicContainerTests;
+
+abstract class AbstractLdpBasicContainmentTests implements LdpBasicContainerTests {
+
+    private static final Client client = newBuilder().build();
+
+    @TestHTTPResource
+    URL url;
+
+    private String container;
+
+    @Override
+    public void setContainerLocation(final String location) {
+        container = location;
+    }
+
+    @Override
+    public String getContainerLocation() {
+        return container;
+    }
+
+    @Override
+    public Client getClient() {
+        return client;
+    }
+
+    @Override
+    public String getBaseURL() {
+        return url.toString();
+    }
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractLdpBinaryTests.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractLdpBinaryTests.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static javax.ws.rs.client.ClientBuilder.newBuilder;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+
+import java.net.URL;
+
+import javax.ws.rs.client.Client;
+
+import org.trellisldp.test.LdpBinaryTests;
+
+abstract class AbstractLdpBinaryTests implements LdpBinaryTests {
+
+    private static final Client client = newBuilder().build();
+
+    @TestHTTPResource
+    URL url;
+
+    private String resource;
+
+    @Override
+    public void setResourceLocation(final String location) {
+        resource = location;
+    }
+
+    @Override
+    public String getResourceLocation() {
+        return resource;
+    }
+
+    @Override
+    public Client getClient() {
+        return client;
+    }
+
+    @Override
+    public String getBaseURL() {
+        return url.toString();
+    }
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractLdpRdfTests.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractLdpRdfTests.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static java.util.Collections.emptySet;
+import static javax.ws.rs.client.ClientBuilder.newBuilder;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+
+import java.net.URL;
+import java.util.Set;
+
+import javax.ws.rs.client.Client;
+
+import org.trellisldp.test.LdpRdfTests;
+
+abstract class AbstractLdpRdfTests implements LdpRdfTests {
+
+    private static final Client client = newBuilder().build();
+
+    @TestHTTPResource
+    URL url;
+
+    private String resource;
+
+    @Override
+    public Set<String> supportedJsonLdProfiles() {
+        return emptySet();
+    }
+
+    @Override
+    public void setResourceLocation(final String location) {
+        resource = location;
+    }
+
+    @Override
+    public String getResourceLocation() {
+        return resource;
+    }
+
+    @Override
+    public Client getClient() {
+        return client;
+    }
+
+    @Override
+    public String getBaseURL() {
+        return url.toString();
+    }
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractMementoBinaryTests.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractMementoBinaryTests.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static javax.ws.rs.client.ClientBuilder.newBuilder;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+
+import java.net.URL;
+
+import javax.ws.rs.client.Client;
+
+import org.trellisldp.test.MementoBinaryTests;
+
+abstract class AbstractMementoBinaryTests implements MementoBinaryTests {
+
+    private static final Client client = newBuilder().build();
+
+    @TestHTTPResource
+    URL url;
+
+    private String resource;
+    private String binary;
+
+    @Override
+    public Client getClient() {
+        return client;
+    }
+
+    @Override
+    public String getBaseURL() {
+        return url.toString();
+    }
+
+    @Override
+    public void setBinaryLocation(final String location) {
+        binary = location;
+    }
+
+    @Override
+    public String getBinaryLocation() {
+        return binary;
+    }
+
+    @Override
+    public void setResourceLocation(final String location) {
+        resource = location;
+    }
+
+    @Override
+    public String getResourceLocation() {
+        return resource;
+    }
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractMementoRdfTests.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractMementoRdfTests.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static javax.ws.rs.client.ClientBuilder.newBuilder;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+
+import java.net.URL;
+
+import javax.ws.rs.client.Client;
+
+import org.trellisldp.test.MementoResourceTests;
+
+abstract class AbstractMementoRdfTests implements MementoResourceTests {
+
+    private static final Client client = newBuilder().build();
+
+    @TestHTTPResource
+    URL url;
+
+    private String resource;
+    private String binary;
+
+    @Override
+    public Client getClient() {
+        return client;
+    }
+
+    @Override
+    public String getBaseURL() {
+        return url.toString();
+    }
+
+    @Override
+    public void setBinaryLocation(final String location) {
+        binary = location;
+    }
+
+    @Override
+    public String getBinaryLocation() {
+        return binary;
+    }
+
+    @Override
+    public void setResourceLocation(final String location) {
+        resource = location;
+    }
+
+    @Override
+    public String getResourceLocation() {
+        return resource;
+    }
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractMementoTimeMapTests.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/AbstractMementoTimeMapTests.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static javax.ws.rs.client.ClientBuilder.newBuilder;
+
+import io.quarkus.test.common.http.TestHTTPResource;
+
+import java.net.URL;
+
+import javax.ws.rs.client.Client;
+
+import org.trellisldp.test.MementoTimeMapTests;
+
+abstract class AbstractMementoTimeMapTests implements MementoTimeMapTests {
+
+    private static final Client client = newBuilder().build();
+
+    @TestHTTPResource
+    URL url;
+
+    private String resource;
+    private String binary;
+
+    @Override
+    public Client getClient() {
+        return client;
+    }
+
+    @Override
+    public String getBaseURL() {
+        return url.toString();
+    }
+
+    @Override
+    public void setBinaryLocation(final String location) {
+        binary = location;
+    }
+
+    @Override
+    public String getBinaryLocation() {
+        return binary;
+    }
+
+    @Override
+    public void setResourceLocation(final String location) {
+        resource = location;
+    }
+
+    @Override
+    public String getResourceLocation() {
+        return resource;
+    }
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraApplicationTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraApplicationTest.java
@@ -11,7 +11,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.trellisldp.ext.db.webapp;
+package org.trellisldp.ext.webapp;
 
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
@@ -20,23 +20,20 @@ import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @DisabledOnOs(WINDOWS)
-@EnabledIfEnvironmentVariable(named = "QUARKUS_EXTERNAL_PGSQL", matches = "true")
+@EnabledIfSystemProperty(named = "trellis.test.cassandra.enable", matches = "true")
 @QuarkusTest
-class PgsqlApplicationTest extends AbstractApplicationTests {
+class CassandraApplicationTest extends AbstractApplicationTests {
 
     @BeforeAll
-    static void setUp() throws Exception {
-        System.setProperty("quarkus.datasource.username", "postgres");
-        System.clearProperty("quarkus.datasource.password");
-        System.setProperty("quarkus.datasource.url", "jdbc:postgresql://localhost/trellis");
+    static void setUp() {
+        System.setProperty("quarkus.flyway.migrate-at-start", "false");
     }
 
     @AfterAll
-    static void tearDown() throws Exception {
-        System.clearProperty("quarkus.datasource.url");
-        System.clearProperty("quarkus.datasource.username");
+    static void tearDown() {
+        System.clearProperty("quarkus.flyway.migrate-at-start");
     }
 }

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraLdpBasicContainmentTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraLdpBasicContainmentTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@DisabledOnOs(WINDOWS)
+@EnabledIfSystemProperty(named = "trellis.test.cassandra.enable", matches = "true")
+@QuarkusTest
+class CassandraLdpBasicContainmentTest extends AbstractLdpBasicContainmentTests {
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraLdpBinaryTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraLdpBinaryTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@DisabledOnOs(WINDOWS)
+@EnabledIfSystemProperty(named = "trellis.test.cassandra.enable", matches = "true")
+@QuarkusTest
+class CassandraLdpBinaryTest extends AbstractLdpBinaryTests {
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraLdpRdfTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraLdpRdfTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@DisabledOnOs(WINDOWS)
+@EnabledIfSystemProperty(named = "trellis.test.cassandra.enable", matches = "true")
+@QuarkusTest
+class CassandraLdpRdfTest extends AbstractLdpRdfTests {
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraMementoBinaryTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraMementoBinaryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@DisabledOnOs(WINDOWS)
+@EnabledIfSystemProperty(named = "trellis.test.cassandra.enable", matches = "true")
+@QuarkusTest
+class CassandraMementoBinaryTest extends AbstractMementoBinaryTests {
+    @Test
+    @Disabled
+    @Override
+    public void testMementoContent() {
+        // ignoring for now because the implementation is slightly different
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void testMementoDateTimeHeader() {
+        // ignoring for now because the implementation is slightly different
+    }
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraMementoRdfTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraMementoRdfTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@DisabledOnOs(WINDOWS)
+@EnabledIfSystemProperty(named = "trellis.test.cassandra.enable", matches = "true")
+@QuarkusTest
+class CassandraMementoRdfTest extends AbstractMementoRdfTests {
+    @Test
+    @Disabled
+    @Override
+    public void testMementoContent() {
+        // ignoring for now because the implementation is slightly different
+    }
+
+    @Test
+    @Disabled
+    @Override
+    public void testMementoDateTimeHeader() {
+        // ignoring for now because the implementation is slightly different
+    }
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraMementoTimeMapTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/CassandraMementoTimeMapTest.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@DisabledOnOs(WINDOWS)
+@EnabledIfSystemProperty(named = "trellis.test.cassandra.enable", matches = "true")
+@QuarkusTest
+class CassandraMementoTimeMapTest extends AbstractMementoTimeMapTests {
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/EmbeddedPgsqlApplicationTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/EmbeddedPgsqlApplicationTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.trellisldp.ext.webapp;
+
+import static org.junit.jupiter.api.condition.OS.WINDOWS;
+
+import com.opentable.db.postgres.embedded.EmbeddedPostgres;
+
+import io.quarkus.test.junit.QuarkusTest;
+
+import org.apache.commons.text.RandomStringGenerator;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+@DisabledOnOs(WINDOWS)
+@EnabledIfSystemProperty(named = "trellis.test.quarkus.embedded-pgsql", matches = "true")
+@QuarkusTest
+class EmbeddedPgsqlApplicationTest extends AbstractApplicationTests {
+
+    private static EmbeddedPostgres pg;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        pg = EmbeddedPostgres.builder()
+            .setDataDirectory("/tmp/testing/" + "pgdata-" + new RandomStringGenerator
+                    .Builder().withinRange('a', 'z').build().generate(10)).start();
+        System.setProperty("quarkus.datasource.username", "postgres");
+        System.setProperty("quarkus.datasource.password", "postgres");
+        System.setProperty("quarkus.datasource.url", "jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        System.clearProperty("quarkus.datasource.url");
+        System.clearProperty("quarkus.datasource.username");
+        System.clearProperty("quarkus.datasource.password");
+        pg.close();
+    }
+}

--- a/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/PgsqlApplicationTest.java
+++ b/platform/quarkus/src/test/java/org/trellisldp/ext/webapp/PgsqlApplicationTest.java
@@ -11,42 +11,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.trellisldp.ext.db.webapp;
+package org.trellisldp.ext.webapp;
 
 import static org.junit.jupiter.api.condition.OS.WINDOWS;
 
-import com.opentable.db.postgres.embedded.EmbeddedPostgres;
-
 import io.quarkus.test.junit.QuarkusTest;
 
-import org.apache.commons.text.RandomStringGenerator;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 @DisabledOnOs(WINDOWS)
-@DisabledIfEnvironmentVariable(named = "QUARKUS_EXTERNAL_PGSQL", matches = "true")
+@EnabledIfSystemProperty(named = "trellis.test.quarkus.external-pgsql", matches = "true")
 @QuarkusTest
-class EmbeddedPgsqlApplicationTest extends AbstractApplicationTests {
-
-    private static EmbeddedPostgres pg;
+class PgsqlApplicationTest extends AbstractApplicationTests {
 
     @BeforeAll
     static void setUp() throws Exception {
-        pg = EmbeddedPostgres.builder()
-            .setDataDirectory("/tmp/testing/" + "pgdata-" + new RandomStringGenerator
-                    .Builder().withinRange('a', 'z').build().generate(10)).start();
         System.setProperty("quarkus.datasource.username", "postgres");
-        System.setProperty("quarkus.datasource.password", "postgres");
-        System.setProperty("quarkus.datasource.url", "jdbc:postgresql://localhost:" + pg.getPort() + "/postgres");
+        System.clearProperty("quarkus.datasource.password");
+        System.setProperty("quarkus.datasource.url", "jdbc:postgresql://localhost/trellis");
     }
 
     @AfterAll
     static void tearDown() throws Exception {
         System.clearProperty("quarkus.datasource.url");
         System.clearProperty("quarkus.datasource.username");
-        System.clearProperty("quarkus.datasource.password");
-        pg.close();
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,14 +18,17 @@ include ':trellis-cassandra'
 include ':trellis-db'
 include ':trellis-db-app'
 include ':trellis-db-deployment'
-include ':trellis-db-quarkus'
 include ':trellis-ext-bom'
+include ':trellis-namespaces'
+include ':trellis-quarkus'
 
 project(':trellis-aws').projectDir = "$rootDir/aws" as File
 project(':trellis-cassandra').projectDir = "$rootDir/cassandra" as File
 project(':trellis-db').projectDir = "$rootDir/db" as File
+project(':trellis-namespaces').projectDir = "$rootDir/namespaces" as File
+
 project(':trellis-db-app').projectDir = "$rootDir/platform/dropwizard" as File
 project(':trellis-db-deployment').projectDir = "$rootDir/platform/deployment" as File
-project(':trellis-db-quarkus').projectDir = "$rootDir/platform/quarkus" as File
+project(':trellis-quarkus').projectDir = "$rootDir/platform/quarkus" as File
 
 project(':trellis-ext-bom').projectDir = "$rootDir/platform/bom" as File


### PR DESCRIPTION
There are a good number of changes here, most of which fall into these categories:

1) The CDI bean injection mechanism has been extended to include many more classes
2) The datastax driver will fail fast when issuing a synchronous query inside an async processor, so a lot of the query code had to be reworked
