### PR TITLE
Simplify constructors/methods

### DIFF
--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraBuildingService.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraBuildingService.java
@@ -22,6 +22,8 @@ import java.time.Instant;
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 import org.slf4j.Logger;
+import org.trellisldp.api.BinaryMetadata;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.api.Resource;
 
 interface CassandraBuildingService {
@@ -35,19 +37,27 @@ interface CassandraBuildingService {
         log.debug("{} was found, computing metadata.", id);
         final IRI ixnModel = metadata.get("interactionModel", IRI.class);
         log.debug("Found interactionModel = {} for resource {}", ixnModel, id);
+        final IRI container = metadata.get("container", IRI.class);
+        log.debug("Found container = {} for resource {}", container, id);
         final boolean hasAcl = metadata.getBoolean("hasAcl");
         log.debug("Found hasAcl = {} for resource {}", hasAcl, id);
+
         final IRI binaryId = metadata.get("binaryIdentifier", IRI.class);
         log.debug("Found binaryIdentifier = {} for resource {}", binaryId, id);
         final String mimeType = metadata.getString("mimetype");
         log.debug("Found mimeType = {} for resource {}", mimeType, id);
-        final IRI container = metadata.get("container", IRI.class);
-        log.debug("Found container = {} for resource {}", container, id);
+
         final Instant modified = metadata.get("modified", Instant.class);
         log.debug("Found modified = {} for resource {}", modified, id);
         final Dataset dataset = metadata.get("quads", Dataset.class);
         log.debug("Found dataset = {} for resource {}", dataset, id);
 
-        return new CassandraResource(id, ixnModel, hasAcl, binaryId, mimeType, container, modified, dataset);
+        final BinaryMetadata binary = binaryId != null ?
+            BinaryMetadata.builder(binaryId).mimeType(mimeType).build() : null;
+
+        final Metadata meta = Metadata.builder(id).container(container).interactionModel(ixnModel)
+            .hasAcl(hasAcl).binary(binary).build();
+
+        return new CassandraResource(meta, modified, dataset);
     }
 }

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraMementoService.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraMementoService.java
@@ -22,7 +22,6 @@ import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.uuid.Uuids;
 
 import java.time.Instant;
-import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -34,8 +33,8 @@ import javax.inject.Inject;
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 import org.slf4j.Logger;
-import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.MementoService;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.api.Resource;
 import org.trellisldp.ext.cassandra.query.rdf.GetFirstMemento;
 import org.trellisldp.ext.cassandra.query.rdf.GetMemento;
@@ -75,18 +74,13 @@ public class CassandraMementoService implements MementoService, CassandraBuildin
     @Override
     public CompletionStage<Void> put(final Resource r) {
 
-        final IRI id = r.getIdentifier();
-        final IRI ixnModel = r.getInteractionModel();
-        final IRI container = r.getContainer().orElse(null);
-        final Optional<BinaryMetadata> binary = r.getBinaryMetadata();
-        final IRI binaryIdentifier = binary.map(BinaryMetadata::getIdentifier).orElse(null);
-        final String mimeType = binary.flatMap(BinaryMetadata::getMimeType).orElse(null);
+        final Metadata metadata = Metadata.builder(r).build();
         final Dataset data = r.dataset();
         final Instant modified = r.getModified();
         final UUID creation = Uuids.timeBased();
 
-        LOGGER.debug("Writing Memento for {} at time: {}", id, modified);
-        return mementoize.execute(ixnModel, mimeType, container, data, modified, binaryIdentifier, creation, id);
+        LOGGER.debug("Writing Memento for {} at time: {}", metadata.getIdentifier(), modified);
+        return mementoize.execute(metadata, modified, data, creation);
     }
 
     //@formatter:off

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraResource.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraResource.java
@@ -14,10 +14,6 @@
 package org.trellisldp.ext.cassandra;
 
 import static org.slf4j.LoggerFactory.getLogger;
-import static org.trellisldp.api.BinaryMetadata.builder;
-import static org.trellisldp.vocabulary.LDP.Container;
-import static org.trellisldp.vocabulary.LDP.NonRDFSource;
-import static org.trellisldp.vocabulary.LDP.getSuperclassOf;
 
 import java.time.Instant;
 import java.util.Optional;
@@ -28,56 +24,36 @@ import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Quad;
 import org.slf4j.Logger;
 import org.trellisldp.api.BinaryMetadata;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.api.Resource;
 
 class CassandraResource implements Resource {
 
     private static final Logger log = getLogger(CassandraResource.class);
 
-    private final IRI identifier;
-    private final IRI container;
-    private final IRI interactionModel;
-
-    final boolean hasAcl;
-    final boolean isContainer;
-
+    private final Metadata metadata;
+    private final Dataset dataset;
     private final Instant modified;
 
-    private final BinaryMetadata binary;
-
-    private final Dataset dataset;
-
-    public CassandraResource(final IRI id, final IRI ixnModel, final boolean hasAcl, final IRI binaryIdentifier,
-            final String mimeType, final IRI container, final Instant modified, final Dataset dataset) {
-        this.identifier = id;
-        this.interactionModel = ixnModel;
-        this.isContainer = Container.equals(ixnModel) || Container.equals(getSuperclassOf(ixnModel));
-        this.hasAcl = hasAcl;
-        this.container = container;
-        log.trace("Resource is {}a container.", !isContainer ? "not " : "");
-        this.modified = modified;
-        final boolean isBinary = NonRDFSource.equals(ixnModel);
-        this.binary = isBinary ? builder(binaryIdentifier).mimeType(mimeType).build() : null;
-        log.trace("Resource is {}a NonRDFSource.", !isBinary ? "not " : "");
+    public CassandraResource(final Metadata metadata, final Instant modified, final Dataset dataset) {
+        this.metadata = metadata;
         this.dataset = dataset;
+        this.modified = modified;
     }
 
     @Override
     public IRI getIdentifier() {
-        return identifier;
+        return metadata.getIdentifier();
     }
 
-    /**
-     * @return a container for this resource
-     */
     @Override
     public Optional<IRI> getContainer() {
-        return Optional.ofNullable(container);
+        return metadata.getContainer();
     }
 
     @Override
     public IRI getInteractionModel() {
-        return interactionModel;
+        return metadata.getInteractionModel();
     }
 
     @Override
@@ -87,12 +63,12 @@ class CassandraResource implements Resource {
 
     @Override
     public boolean hasAcl() {
-        return hasAcl;
+        return metadata.getHasAcl();
     }
 
     @Override
     public Optional<BinaryMetadata> getBinaryMetadata() {
-        return Optional.ofNullable(binary);
+        return metadata.getBinary();
     }
 
     @Override

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraResourceService.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraResourceService.java
@@ -28,11 +28,9 @@ import static org.trellisldp.vocabulary.LDP.getSuperclassOf;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.uuid.Uuids;
 
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ExecutionException;
@@ -46,7 +44,6 @@ import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.IRI;
 import org.apache.commons.rdf.api.Quad;
 import org.slf4j.Logger;
-import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.Metadata;
 import org.trellisldp.api.Resource;
 import org.trellisldp.api.ResourceService;
@@ -199,15 +196,6 @@ class CassandraResourceService implements ResourceService, CassandraBuildingServ
     }
 
     private CompletionStage<Void> write(final Metadata meta, final Dataset data) {
-        final IRI id = meta.getIdentifier();
-        final IRI ixnModel = meta.getInteractionModel();
-        final IRI container = meta.getContainer().orElse(null);
-
-        final Optional<BinaryMetadata> binary = meta.getBinary();
-        final IRI binaryIdentifier = binary.map(BinaryMetadata::getIdentifier).orElse(null);
-        final String mimeType = binary.flatMap(BinaryMetadata::getMimeType).orElse(null);
-        final Instant now = now();
-
-        return mutableInsert.execute(ixnModel, mimeType, container, data, now, binaryIdentifier, Uuids.timeBased(), id);
+        return mutableInsert.execute(meta, now(), data, Uuids.timeBased());
     }
 }

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/MutableInsert.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/query/rdf/MutableInsert.java
@@ -26,8 +26,9 @@ import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 
 import org.apache.commons.rdf.api.Dataset;
-import org.apache.commons.rdf.api.IRI;
 import org.slf4j.Logger;
+import org.trellisldp.api.BinaryMetadata;
+import org.trellisldp.api.Metadata;
 import org.trellisldp.ext.cassandra.MutableWriteConsistency;
 
 /**
@@ -61,21 +62,20 @@ public class MutableInsert extends ResourceQuery {
     }
 
     /**
-     * @param ixnModel an {@link IRI} for the interaction model for this resource
-     * @param mimeType if this resource has a binary, the mimeType therefor
-     * @param container if this resource has a container, the {@link IRI} therefor
-     * @param data RDF for this resource
+     * @param metadata the metadata for this resource
      * @param modified the time at which this resource was last modified
-     * @param binaryIdentifier if this resource has a binary, the identifier therefor
+     * @param data RDF for this resource
      * @param creation a time-based (version 1) UUID for the moment this resource is created
-     * @param id an {@link IRI} that identifies this resource
      * @return whether and when it has been inserted
      */
-    public CompletionStage<Void> execute(final IRI ixnModel, final String mimeType, final IRI container,
-            final Dataset data, final Instant modified, final IRI binaryIdentifier, final UUID creation, final IRI id) {
+    public CompletionStage<Void> execute(final Metadata metadata, final Instant modified, final Dataset data,
+            final UUID creation) {
         return preparedStatementAsync().thenApply(stmt ->
-                stmt.bind(ixnModel, mimeType, container, data, modified, binaryIdentifier, creation, id)
-                    .setConsistencyLevel(consistency))
+                stmt.bind(metadata.getInteractionModel(),
+                    metadata.getBinary().flatMap(BinaryMetadata::getMimeType).orElse(null),
+                    metadata.getContainer().orElse(null), data, modified,
+                    metadata.getBinary().map(BinaryMetadata::getIdentifier).orElse(null),
+                    creation, metadata.getIdentifier()).setConsistencyLevel(consistency))
             .thenCompose(session::executeAsync)
             .thenAccept(r -> LOGGER.debug("Executed query: {}", queryString));
     }


### PR DESCRIPTION
This makes use of `Metadata` objects instead of using methods with a ton of arguments.