### PR TITLE
Align version with main trellis code

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.3.0-SNAPSHOT
+version = 0.9.0-SNAPSHOT


### PR DESCRIPTION
The trellis-extensions codebase is currently versioned independently of the main trellis codebase (0.3.0-SNAPSHOT vs. 0.9.0-SNAPSHOT). While there are advantages to having independent release cycles, this isn't needed in practice and it simply leads to confusion. At the 1.0 release, everything will be aligned anyway, and there seems to be no clear drawback to aligning the versions now, especially since there are only two repositories at play.