### PR TITLE
Adjust runtime scopes

### DIFF
--- a/aws/build.gradle
+++ b/aws/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testImplementation "org.trellisldp:trellis-event-jackson"
     testImplementation "org.trellisldp:trellis-constraint-rules"
 
-    testRuntimeClasspath "ch.qos.logback:logback-classic:$logbackVersion"
+    testRuntimeOnly "ch.qos.logback:logback-classic:$logbackVersion"
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ allprojects { subproj ->
         testImplementation enforcedPlatform("org.junit:junit-bom:$junitVersion")
         testImplementation("org.apiguardian:apiguardian-api:${apiguardianVersion}")
         testImplementation("org.junit.jupiter:junit-jupiter-api")
-        testRuntimeClasspath("org.junit.jupiter:junit-jupiter-engine")
+        testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
     }
 
     gradle.projectsEvaluated {

--- a/cassandra/build.gradle
+++ b/cassandra/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
     testImplementation "org.trellisldp:trellis-test"
 
-    testRuntimeClasspath("ch.qos.logback:logback-classic:$logbackVersion")
+    testRuntimeOnly("ch.qos.logback:logback-classic:$logbackVersion")
 }
 
 test {

--- a/platform/deployment/build.gradle
+++ b/platform/deployment/build.gradle
@@ -10,12 +10,12 @@ applicationName = 'trellis-db'
 dependencies {
     implementation project(':trellis-db-app')
 
-    runtimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
-    runtimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    runtimeOnly "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    runtimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
 
-    runtimeClasspath "mysql:mysql-connector-java:$mysqlVersion"
-    runtimeClasspath "org.postgresql:postgresql:$postgresVersion"
-    runtimeClasspath "org.yaml:snakeyaml:$snakeyamlVersion"
+    runtimeOnly "mysql:mysql-connector-java:$mysqlVersion"
+    runtimeOnly "org.postgresql:postgresql:$postgresVersion"
+    runtimeOnly "org.yaml:snakeyaml:$snakeyamlVersion"
 }
 
 ospackage {

--- a/platform/dropwizard/build.gradle
+++ b/platform/dropwizard/build.gradle
@@ -41,8 +41,8 @@ dependencies {
 
     runtimeOnly "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
     runtimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
-    runtimeOnly "org.postgresql:postgresql:$postgresVersion"
     runtimeOnly "mysql:mysql-connector-java:$mysqlVersion"
+    runtimeOnly "org.postgresql:postgresql:$postgresVersion"
     runtimeOnly "org.yaml:snakeyaml:$snakeyamlVersion"
 
     testImplementation "com.h2database:h2:$h2Version"

--- a/platform/quarkus/build.gradle
+++ b/platform/quarkus/build.gradle
@@ -73,9 +73,9 @@ dependencies {
     }
     implementation "org.slf4j:slf4j-api:$slf4jVersion"
 
-    runtimeClasspath "jakarta.activation:jakarta.activation-api:$activationApiVersion"
-    runtimeClasspath "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
-    runtimeClasspath "org.yaml:snakeyaml:$snakeyamlVersion"
+    runtimeOnly "jakarta.activation:jakarta.activation-api:$activationApiVersion"
+    runtimeOnly "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    runtimeOnly "org.yaml:snakeyaml:$snakeyamlVersion"
 
     testImplementation "com.opentable.components:otj-pg-embedded:$otjPgVersion"
     testImplementation "io.quarkus:quarkus-junit5"


### PR DESCRIPTION
This adjusts the dependency scope to use `runtimeOnly` instead of `runtimeClasspath` as per the [gradle documentation](https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_configurations_graph).