### PR TITLE
Use provided scope for JavaEE dependencies

### DIFF
--- a/aws/build.gradle
+++ b/aws/build.gradle
@@ -10,6 +10,7 @@ ext {
 dependencies {
     implementation enforcedPlatform("org.trellisldp:trellis-bom:${trellisVersion}")
 
+    api "jakarta.enterprise:jakarta.enterprise.cdi-api:$cdiApiVersion"
     api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
     api "org.apache.commons:commons-rdf-api:$commonsRdfVersion"
     api "com.amazonaws:aws-java-sdk-s3:$awsVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -215,6 +215,10 @@ subprojects { subproj ->
                 pom.withXml {
                     // eliminate test-scoped dependencies
                     asNode().dependencies.removeAll { dep -> dep.scope == "test" }
+                    // use provided scope for JavaEE dependencies
+                    asNode().dependencies.each {
+                        deps -> deps.findAll { dep -> dep.groupId[0].text().startsWith("jakarta.") }
+                                    .each { dep -> dep.scope[0].value = "provided" } }
                 }
 
                 from components.java

--- a/cassandra/build.gradle
+++ b/cassandra/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation enforcedPlatform("org.trellisldp:trellis-bom:$trellisVersion")
 
     api "jakarta.annotation:jakarta.annotation-api:$annotationApiVersion"
+    api "jakarta.enterprise:jakarta.enterprise.cdi-api:$cdiApiVersion"
     api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
     api "org.apache.commons:commons-rdf-api:$commonsRdfVersion"
     api("org.apache.commons:commons-rdf-jena:$commonsRdfVersion") {

--- a/db/build.gradle
+++ b/db/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation enforcedPlatform("org.trellisldp:trellis-bom:$trellisVersion")
 
     api "jakarta.annotation:jakarta.annotation-api:$annotationApiVersion"
+    api "jakarta.enterprise:jakarta.enterprise.cdi-api:$cdiApiVersion"
     api "jakarta.inject:jakarta.inject-api:$injectApiVersion"
     api "org.apache.commons:commons-lang3:$commonsLangVersion"
     api "org.apache.commons:commons-rdf-api:$commonsRdfVersion"
@@ -25,11 +26,11 @@ dependencies {
 
     testImplementation "com.google.guava:guava:$guavaVersion"
     testImplementation "com.opentable.components:otj-pg-embedded:$otjPgVersion"
-
-    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
-    testImplementation "org.apache.commons:commons-text:$commonsTextVersion"
     testImplementation "io.smallrye:smallrye-config:$smallryeConfigVersion"
     testImplementation "io.smallrye:smallrye-health:$smallryeHealthVersion"
+    testImplementation "jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion"
+    testImplementation "org.apache.commons:commons-rdf-simple:$commonsRdfVersion"
+    testImplementation "org.apache.commons:commons-text:$commonsTextVersion"
     testImplementation "org.liquibase:liquibase-core:$liquibaseVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
     testImplementation "org.yaml:snakeyaml:$snakeyamlVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,6 +8,7 @@ activationApiVersion = 1.2.1
 annotationApiVersion = 1.3.5
 cdiApiVersion = 2.0.2
 injectApiVersion = 1.0
+jaxbApiVersion = 2.3.2
 jmsApiVersion = 2.0.3
 transactionApiVersion = 1.3.3
 
@@ -47,7 +48,6 @@ awaitilityVersion = 4.0.1
 commonsTextVersion = 1.8
 guavaVersion = 28.1-jre
 h2Version = 1.4.200
-jaxbApiVersion = 2.3.2
 jenaVersion = 3.13.1
 junitVersion = 5.5.2
 logbackVersion = 1.2.3


### PR DESCRIPTION
Related to trellis-ldp/trellis#635

This adds an explicit CDI dependency in places where it was previously relied on as a transitive dependency.