### PR TITLE
Allow default ACL to be overridden

### DIFF
--- a/db/src/main/resources/db/migration/V0.3__Trellis.sql
+++ b/db/src/main/resources/db/migration/V0.3__Trellis.sql
@@ -50,7 +50,7 @@ COMMENT ON COLUMN public.resource.ldp_is_member_of_relation IS 'If this resource
 COMMENT ON COLUMN public.resource.ldp_inserted_content_relation IS 'If this resource is a LDP-DC or LDP-IC, this column holds the ldp:insertedContentRelation value.';
 
 INSERT INTO public.resource (id, subject, interaction_model, modified, deleted, acl) VALUES
-(0,'trellis:data/','http://www.w3.org/ns/ldp#BasicContainer',0,'f','t');
+(0,'trellis:data/','http://www.w3.org/ns/ldp#BasicContainer',0,'f','f');
 
 CREATE INDEX idx_resource_ldp ON public.resource (ldp_member);
 CREATE INDEX idx_resource_parent ON public.resource (is_part_of);
@@ -81,13 +81,6 @@ COMMENT ON COLUMN public.acl.predicate IS 'The RDF predicate for the triple.';
 COMMENT ON COLUMN public.acl.object IS 'The RDF object for the triple.';
 COMMENT ON COLUMN public.acl.lang IS 'If the object is a string literal, this holds the language tag, if relevant.';
 COMMENT ON COLUMN public.acl.datatype IS 'If the object is a literal, this holds the datatype IRI of that literal value.';
-
-INSERT INTO public.acl (resource_id, subject, predicate, object) VALUES
-(0,'trellis:data/#auth','http://www.w3.org/ns/auth/acl#mode','http://www.w3.org/ns/auth/acl#Read'),
-(0,'trellis:data/#auth','http://www.w3.org/ns/auth/acl#mode','http://www.w3.org/ns/auth/acl#Write'),
-(0,'trellis:data/#auth','http://www.w3.org/ns/auth/acl#mode','http://www.w3.org/ns/auth/acl#Control'),
-(0,'trellis:data/#auth','http://www.w3.org/ns/auth/acl#agentClass','http://xmlns.com/foaf/0.1/Agent'),
-(0,'trellis:data/#auth','http://www.w3.org/ns/auth/acl#accessTo','trellis:data/');
 
 CREATE INDEX idx_acl ON public.acl (resource_id);
 

--- a/db/src/main/resources/migrations.yml
+++ b/db/src/main/resources/migrations.yml
@@ -392,22 +392,6 @@ databaseChangeLog:
                         name: acl
                         type: BOOLEAN
                 file: org/trellisldp/ext/db/initial_resource${csv}.csv
-            - loadData:
-                tableName: acl
-                columns:
-                    - column:
-                        name: resource_id
-                        type: NUMERIC
-                    - column:
-                        name: subject
-                        type: STRING
-                    - column:
-                        name: predicate
-                        type: STRING
-                    - column:
-                        name: object
-                        type: STRING
-                file: org/trellisldp/ext/db/initial_acl${csv}.csv
     - changeSet:
         id: 2
         author: acoburn

--- a/db/src/main/resources/org/trellisldp/ext/db/initial_acl.csv
+++ b/db/src/main/resources/org/trellisldp/ext/db/initial_acl.csv
@@ -1,6 +1,0 @@
-resource_id,subject,predicate,object
-0,trellis:data/#auth,http://www.w3.org/ns/auth/acl#mode,http://www.w3.org/ns/auth/acl#Read
-0,trellis:data/#auth,http://www.w3.org/ns/auth/acl#mode,http://www.w3.org/ns/auth/acl#Write
-0,trellis:data/#auth,http://www.w3.org/ns/auth/acl#mode,http://www.w3.org/ns/auth/acl#Control
-0,trellis:data/#auth,http://www.w3.org/ns/auth/acl#agentClass,http://xmlns.com/foaf/0.1/Agent
-0,trellis:data/#auth,http://www.w3.org/ns/auth/acl#accessTo,trellis:data/

--- a/db/src/main/resources/org/trellisldp/ext/db/initial_acl_mysql.csv
+++ b/db/src/main/resources/org/trellisldp/ext/db/initial_acl_mysql.csv
@@ -1,6 +1,0 @@
-resource_id,subject,predicate,object
-1,trellis:data/#auth,http://www.w3.org/ns/auth/acl#mode,http://www.w3.org/ns/auth/acl#Read
-1,trellis:data/#auth,http://www.w3.org/ns/auth/acl#mode,http://www.w3.org/ns/auth/acl#Write
-1,trellis:data/#auth,http://www.w3.org/ns/auth/acl#mode,http://www.w3.org/ns/auth/acl#Control
-1,trellis:data/#auth,http://www.w3.org/ns/auth/acl#agentClass,http://xmlns.com/foaf/0.1/Agent
-1,trellis:data/#auth,http://www.w3.org/ns/auth/acl#accessTo,trellis:data/

--- a/db/src/main/resources/org/trellisldp/ext/db/initial_resource.csv
+++ b/db/src/main/resources/org/trellisldp/ext/db/initial_resource.csv
@@ -1,2 +1,2 @@
 id,subject,interaction_model,modified,acl
-0,trellis:data/,http://www.w3.org/ns/ldp#BasicContainer,0,TRUE
+0,trellis:data/,http://www.w3.org/ns/ldp#BasicContainer,0,FALSE

--- a/db/src/main/resources/org/trellisldp/ext/db/initial_resource_mysql.csv
+++ b/db/src/main/resources/org/trellisldp/ext/db/initial_resource_mysql.csv
@@ -1,2 +1,2 @@
 id,subject,interaction_model,modified,acl
-1,trellis:data/,http://www.w3.org/ns/ldp#BasicContainer,0,TRUE
+1,trellis:data/,http://www.w3.org/ns/ldp#BasicContainer,0,FALSE

--- a/db/src/test/java/org/trellisldp/ext/db/DBResourceTest.java
+++ b/db/src/test/java/org/trellisldp/ext/db/DBResourceTest.java
@@ -51,7 +51,6 @@ import java.util.concurrent.CompletionException;
 import org.apache.commons.rdf.api.Dataset;
 import org.apache.commons.rdf.api.Graph;
 import org.apache.commons.rdf.api.IRI;
-import org.apache.commons.rdf.api.Quad;
 import org.apache.commons.rdf.api.RDF;
 import org.apache.commons.text.RandomStringGenerator;
 import org.jdbi.v3.core.Jdbi;
@@ -209,11 +208,7 @@ class DBResourceTest {
     void getAclQuads() {
         assertAll(() ->
             DBResource.findResource(pg.getPostgresDatabase(), root, extensions, true).thenAccept(res -> {
-                final Graph acl = rdf.createGraph();
-                res.stream(Trellis.PreferAccessControl).map(Quad::asTriple).forEach(acl::add);
-                assertTrue(acl.contains(null, ACL.mode, ACL.Read));
-                assertTrue(acl.contains(null, ACL.mode, ACL.Write));
-                assertTrue(acl.contains(null, ACL.mode, ACL.Control));
+                assertEquals(0L, res.stream(Trellis.PreferAccessControl).count());
                 assertEquals(0L, res.stream(Trellis.PreferUserManaged).count());
                 assertEquals(1L, res.stream(Trellis.PreferServerManaged).count());
             }).toCompletableFuture().join());


### PR DESCRIPTION
This removes the tight-coupling to trellis-webac. The ACL data gets initialized automatically by the webac component anyway.