### PR TITLE
Add license download configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -215,6 +215,11 @@ subprojects { subproj ->
         }
     }
 
+    downloadLicenses {
+        includeProjectDependencies = true
+        dependencyConfiguration = 'compileClasspath'
+    }
+
     publishing {
         publications {
             maven(MavenPublication) {


### PR DESCRIPTION
This makes it possible to run `gradlew downloadLicenses` to see the licenses for the various dependencies.