### PR TITLE
Use released trellis version

### DIFF
--- a/aws/build.gradle
+++ b/aws/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     testImplementation "org.apache.commons:commons-text:$commonsTextVersion"
     testImplementation "io.smallrye.config:smallrye-config:$smallryeConfigVersion"
     testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
 
     testImplementation "org.trellisldp:trellis-event-jackson"
     testImplementation "org.trellisldp:trellis-constraint"

--- a/aws/src/main/java/org/trellisldp/ext/aws/S3BinaryService.java
+++ b/aws/src/main/java/org/trellisldp/ext/aws/S3BinaryService.java
@@ -115,7 +115,7 @@ public class S3BinaryService implements BinaryService {
     }
 
     @Override
-    public String generateIdentifier() {
+    public String generateIdentifier(final IRI identifier) {
         return idService.getSupplier(PREFIX).get();
     }
 

--- a/aws/src/test/java/org/trellisldp/ext/aws/S3BinaryServiceTest.java
+++ b/aws/src/test/java/org/trellisldp/ext/aws/S3BinaryServiceTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 import org.trellisldp.api.BinaryMetadata;
 import org.trellisldp.api.BinaryService;
 import org.trellisldp.api.RDFFactory;
+import org.trellisldp.api.TrellisUtils;
 
 @EnabledIfSystemProperty(named = "trellis.test.aws", matches = "true")
 class S3BinaryServiceTest {
@@ -86,8 +87,9 @@ class S3BinaryServiceTest {
 
     @Test
     void testIdentifier() {
+        final IRI identifier = TrellisUtils.buildTrellisIdentifier("/resource");
         final BinaryService svc = new S3BinaryService();
-        assertTrue(svc.generateIdentifier().startsWith("s3://"));
+        assertTrue(svc.generateIdentifier(identifier).startsWith("s3://"));
     }
 
     @Test
@@ -106,7 +108,7 @@ class S3BinaryServiceTest {
                 throw new IOException("Expected error");
         });
         final BinaryService svc = new S3BinaryService();
-        final IRI identifier = rdf.createIRI(svc.generateIdentifier());
+        final IRI identifier = rdf.createIRI(svc.generateIdentifier(TrellisUtils.buildTrellisIdentifier("/resource")));
         assertThrows(CompletionException.class,
                 svc.setContent(BinaryMetadata.builder(identifier).build(),
                     throwingMockInputStream).toCompletableFuture()::join);

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 ext {
 
     // Trellis core
-    trellisVersion = "0.13.1"
+    trellisVersion = "0.14.0"
 
     // JavaEE
     activationApiVersion = "1.2.2"

--- a/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraBinaryService.java
+++ b/cassandra/src/main/java/org/trellisldp/ext/cassandra/CassandraBinaryService.java
@@ -150,7 +150,7 @@ public class CassandraBinaryService implements BinaryService {
     }
 
     @Override
-    public String generateIdentifier() {
+    public String generateIdentifier(final IRI identifier) {
         return idService.getSupplier().get();
     }
 }


### PR DESCRIPTION
This also contains some other miscellaneous updates (e.g. fix mockito deprecation warnings)